### PR TITLE
feat: add configurable background layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ A production-ready Node.js application for creating highly customizable live HLS
 🎥 **Dynamic Content Switching** - Update video content without interrupting the stream  
 🔄 **Real-time Filter Adjustments** - Modify overlays, text, and effects via ZeroMQ  
 📺 **Layered Overlays** - Support for multiple overlay layers (extensible)  
-🚀 **HLS Live Streaming** - Automatic segment generation and cleanup  
-🌐 **HTTP API** - RESTful API for real-time stream control  
-⚡ **Zero Downtime** - Seamless content transitions using FFmpeg concat demuxer  
+🚀 **HLS Live Streaming** - Automatic segment generation and cleanup
+🌐 **HTTP API** - RESTful API for real-time stream control
+⚡ **Zero Downtime** - Seamless content transitions using FFmpeg concat demuxer
 🛡️ **Production Ready** - Comprehensive error handling and logging
+🖼️ **Persistent Background Layer** - Configurable color and text always behind your overlays
 
 ### 🆕 New in Modular Version
 
@@ -144,6 +145,9 @@ INITIAL_CONTENT=./assets/default.mp4
 LOG_LEVEL=info
 FFMPEG_BINARY=ffmpeg
 FFMPEG_PRESET=ultrafast
+BACKGROUND_COLOR=black
+BACKGROUND_TEXT=""
+BACKGROUND_SIZE=1280x720
 ```
 
 ### Legacy Version
@@ -200,6 +204,16 @@ Add/change overlay on a specific layer:
 curl -X POST http://localhost:3000/update \
   -H "Content-Type: application/json" \
   -d '{"type":"layer","data":{"index":0,"path":"/path/to/overlay.png"}}'
+```
+
+### Update Background Layer
+
+Change the persistent background color or text:
+
+```bash
+curl -X POST http://localhost:3000/update \
+  -H "Content-Type: application/json" \
+  -d '{"type":"background","data":{"color":"#000000","text":"Starting Soon"}}'
 ```
 
 ### Send Real-time Filter Commands

--- a/custom-hls-streamer.js
+++ b/custom-hls-streamer.js
@@ -612,9 +612,22 @@ function setupHttpServer() {
           const filterResult = await sendInstruction(command);
           res.json({ success: filterResult, message: filterResult ? 'Filter command sent' : 'Failed to send filter command' });
           break;
-          
+
+        case 'background':
+          if (data.color) {
+            CONFIG.background.color = data.color;
+          }
+          if (typeof data.text === 'string') {
+            CONFIG.background.text = data.text;
+          }
+          if (ffmpegProcess) {
+            await restartFFmpeg();
+          }
+          res.json({ success: true, message: 'Background updated' });
+          break;
+
         default:
-          res.status(400).json({ success: false, message: 'Invalid update type. Use: content, layer, or filter' });
+          res.status(400).json({ success: false, message: 'Invalid update type. Use: content, layer, filter, or background' });
       }
     } catch (error) {
       logger.error('API error:', error.message);

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -42,11 +42,18 @@ const CONFIG = {
   fifos: {
     baseDir: process.env.FIFO_BASE_DIR || './fifos',
     content: 'content.fifo',
-    layers: process.env.FIFO_LAYERS ? 
-      process.env.FIFO_LAYERS.split(',') : 
+    layers: process.env.FIFO_LAYERS ?
+      process.env.FIFO_LAYERS.split(',') :
       ['overlay1.fifo', 'overlay2.fifo']
   },
-  
+
+  // Persistent background layer
+  background: {
+    color: process.env.BACKGROUND_COLOR || 'black',
+    text: process.env.BACKGROUND_TEXT || '',
+    size: process.env.BACKGROUND_SIZE || '1280x720'
+  },
+
   // Initial content
   initialContent: process.env.INITIAL_CONTENT || './assets/default.mp4',
   

--- a/src/middleware/validation.js
+++ b/src/middleware/validation.js
@@ -165,10 +165,26 @@ function validateUpdateRequest(maxLayers = 2) {
         }
         break;
 
+      case 'background':
+        if (data.color && typeof data.color !== 'string') {
+          return res.status(400).json({
+            success: false,
+            message: 'Background update requires color to be a string'
+          });
+        }
+
+        if (data.text && typeof data.text !== 'string') {
+          return res.status(400).json({
+            success: false,
+            message: 'Background update requires text to be a string'
+          });
+        }
+        break;
+
       default:
         return res.status(400).json({
           success: false,
-          message: `Invalid update type: ${type}. Valid types are: content, layer, filter`
+          message: `Invalid update type: ${type}. Valid types are: content, layer, filter, background`
         });
     }
 

--- a/src/services/ffmpegService.js
+++ b/src/services/ffmpegService.js
@@ -307,15 +307,15 @@ class FFmpegService {
       await this.fifoService.writeContent(CONFIG.initialContent);
     } else {
       logger.warn(`Initial content file not found: ${CONFIG.initialContent}`);
-      logger.info('Creating a basic test pattern as initial content...');
-      
+      logger.info('Creating a blank placeholder video as initial content...');
+
       try {
-        const testPatternPath = path.join(CONFIG.hls.outputDir, 'test_pattern.mp4');
-        await execAsync(`${CONFIG.ffmpeg.binary} -f lavfi -i testsrc=duration=60:size=1280x720:rate=30 -f lavfi -i sine=frequency=1000:duration=60 -c:v libx264 -c:a aac -t 60 "${testPatternPath}" -y`);
-        await this.fifoService.writeContent(testPatternPath);
-        logger.info('Created and initialized with test pattern');
+        const blankPath = path.join(CONFIG.hls.outputDir, 'blank.mp4');
+        await execAsync(`${CONFIG.ffmpeg.binary} -f lavfi -i color=c=${CONFIG.background.color}:size=${CONFIG.background.size}:rate=30 -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=48000 -c:v libx264 -c:a aac -t 60 "${blankPath}" -y`);
+        await this.fifoService.writeContent(blankPath);
+        logger.info('Created and initialized with blank placeholder');
       } catch (error) {
-        logger.error('Failed to create test pattern:', error.message);
+        logger.error('Failed to create blank placeholder:', error.message);
       }
     }
   }

--- a/src/services/ffmpegService.js
+++ b/src/services/ffmpegService.js
@@ -52,12 +52,12 @@ class FFmpegService {
     const args = [];
     
     if (!this.canUseFifos()) {
-      // Simplified Windows approach - use test pattern for now
+      // Simplified Windows approach - generate background color and silent audio
       args.push(
         '-f', 'lavfi',
-        '-i', 'testsrc=duration=3600:size=1280x720:rate=30',
-        '-f', 'lavfi', 
-        '-i', 'sine=frequency=1000:duration=3600'
+        '-i', `color=c=${CONFIG.background.color}:size=${CONFIG.background.size}:rate=30`,
+        '-f', 'lavfi',
+        '-i', 'anullsrc=channel_layout=stereo:sample_rate=48000'
       );
       
       // Simple video encoding for Windows
@@ -78,19 +78,22 @@ class FFmpegService {
         '-ar', '48000'
       );
     } else {
-      // Systems with FIFO support - use FIFO approach
-      // Input arguments - Main content FIFO
+      // Systems with FIFO support - add background and FIFO inputs
       args.push(
+        '-f', 'lavfi',
+        '-i', `color=c=${CONFIG.background.color}:size=${CONFIG.background.size}:rate=30`,
+        '-f', 'lavfi',
+        '-i', 'anullsrc=channel_layout=stereo:sample_rate=48000',
         '-f', 'concat',
         '-safe', '0',
         '-i', this.fifoService.getContentFifoPath()
       );
-      
+
       // Layer input FIFOs
       CONFIG.fifos.layers.forEach((_, index) => {
         args.push('-i', this.fifoService.getLayerFifoPath(index));
       });
-      
+
       // Build filter_complex
       const filterComplex = this.buildFilterComplex();
       args.push('-filter_complex', filterComplex);
@@ -134,46 +137,50 @@ class FFmpegService {
    */
   buildFilterComplex() {
     if (!this.canUseFifos()) {
-      // Simplified filter for Windows - just add text overlay without font file
-      return `[0:v]drawtext=text='HLS Stream - Windows Mode':fontsize=24:fontcolor=white:x=10:y=10[vout];[1:a]anull[aout]`;
-    }
-    
-    const numLayers = CONFIG.fifos.layers.length;
-    let filter = '';
-    
-    if (numLayers === 0) {
-      // No overlays, just pass through with ZMQ
-      filter = `[0:v]zmq=bind_address=tcp\\://\\*\\:${CONFIG.zmq.port}[vout];[0:a]anull[aout]`;
-    } else if (numLayers === 1) {
-      // Single overlay
-      filter = `[0:v][1:v]overlay=0:0,zmq=bind_address=tcp\\://\\*\\:${CONFIG.zmq.port}[vout];[0:a][1:a]amix=inputs=2[aout]`;
-    } else if (numLayers === 2) {
-      // Two overlays (as per default config)
-      filter = `[0:v][1:v]overlay=0:0[tmp];[tmp][2:v]overlay=100:100,zmq=bind_address=tcp\\://\\*\\:${CONFIG.zmq.port}[vout];[0:a][1:a][2:a]amix=inputs=3[aout]`;
-    } else {
-      // Extensible for more overlays - chain them
-      filter = '[0:v]';
-      for (let i = 1; i <= numLayers; i++) {
-        const isLast = i === numLayers;
-        const inputLabel = i === 1 ? '[0:v]' : '[tmp' + (i - 2) + ']';
-        const outputLabel = isLast ? '' : '[tmp' + (i - 1) + ']';
-        
-        if (i === 1) {
-          filter += `[${i}:v]overlay=0:0${outputLabel}`;
-        } else {
-          filter += `;${inputLabel}[${i}:v]overlay=${i * 50}:${i * 50}${outputLabel}`;
-        }
+      // Simplified filter for Windows
+      let chain = '[0:v]';
+      if (CONFIG.background.text) {
+        const text = CONFIG.background.text.replace(/:/g, '\\:');
+        chain += `drawtext=text='${text}':fontsize=24:fontcolor=white:x=10:y=10`;
       }
-      
-      // Add ZMQ filter to the last overlay
-      filter += `,zmq=bind_address=tcp\\://\\*\\:${CONFIG.zmq.port}[vout]`;
-      
-      // Audio mixing
-      const audioInputs = Array.from({length: numLayers + 1}, (_, i) => `[${i}:a]`).join('');
-      filter += `;${audioInputs}amix=inputs=${numLayers + 1}[aout]`;
+      chain += `,zmq=bind_address=tcp\\://\\*\\:${CONFIG.zmq.port}[vout]`;
+      return `${chain};[1:a]anull[aout]`;
     }
-    
-    return filter;
+
+    const numLayers = CONFIG.fifos.layers.length;
+    const parts = [];
+
+    // Background video with optional text
+    if (CONFIG.background.text) {
+      const text = CONFIG.background.text.replace(/:/g, '\\:');
+      parts.push(`[0:v]drawtext=text='${text}':fontsize=24:fontcolor=white:x=10:y=10[bg]`);
+    } else {
+      parts.push(`[0:v]scale=iw:ih[bg]`);
+    }
+
+    // Overlay main content onto background
+    parts.push(`[bg][2:v]overlay=0:0:eof_action=pass:shortest=0[tmp0]`);
+    let lastLabel = 'tmp0';
+
+    // Additional overlay layers
+    for (let i = 0; i < numLayers; i++) {
+      const inputIndex = i + 3; // layer inputs start after bg video/audio and content
+      const outLabel = i === numLayers - 1 ? 'tmp_final' : `tmp${i + 1}`;
+      parts.push(`[${lastLabel}][${inputIndex}:v]overlay=${(i + 1) * 50}:${(i + 1) * 50}:eof_action=pass:shortest=0[${outLabel}]`);
+      lastLabel = outLabel;
+    }
+
+    // ZMQ filter on final video
+    parts.push(`[${lastLabel}]zmq=bind_address=tcp\\://\\*\\:${CONFIG.zmq.port}[vout]`);
+
+    // Audio mixing (background audio + content + overlays)
+    const audioInputs = ['[1:a]', '[2:a]'];
+    for (let i = 0; i < numLayers; i++) {
+      audioInputs.push(`[${i + 3}:a]`);
+    }
+    parts.push(`${audioInputs.join('')}amix=inputs=${audioInputs.length}[aout]`);
+
+    return parts.join(';');
   }
 
   /**
@@ -268,6 +275,15 @@ class FFmpegService {
         }
       }, 10000);
     }
+  }
+
+  /**
+   * Restart FFmpeg process
+   */
+  async restart() {
+    this.stop();
+    await new Promise(resolve => setTimeout(resolve, 500));
+    await this.start();
   }
 
   /**

--- a/tests/unit/services/ffmpegService.test.js
+++ b/tests/unit/services/ffmpegService.test.js
@@ -259,7 +259,7 @@ describe('FFmpegService', () => {
       fs.existsSync = originalExistsSync;
     });
 
-    test('should create test pattern if initial content does not exist on Unix', async () => {
+    test('should create blank placeholder if initial content does not exist on Unix', async () => {
       if (process.platform === 'win32') {
         return; // Skip on Windows
       }
@@ -281,10 +281,10 @@ describe('FFmpegService', () => {
       const logs = mockLogger.getLogs();
       const warnLogs = logs.filter(log => log.level === 'warn');
       const infoLogs = logs.filter(log => log.level === 'info');
-      
+
       assert.isTrue(warnLogs.some(log => log.msg.includes('Initial content file not found')), 'Should log warning');
-      assert.isTrue(infoLogs.some(log => log.msg.includes('Creating a basic test pattern')), 'Should log test pattern creation');
-      
+      assert.isTrue(infoLogs.some(log => log.msg.includes('Creating a blank placeholder')), 'Should log blank placeholder creation');
+
       // Restore
       fs.existsSync = originalExistsSync;
       util.promisify = originalPromisify;

--- a/web/src/components/StreamControls.js
+++ b/web/src/components/StreamControls.js
@@ -36,10 +36,12 @@ const StreamControls = ({ onAction, status, onLog }) => {
   const [contentForm] = Form.useForm();
   const [layerForm] = Form.useForm();
   const [filterForm] = Form.useForm();
+  const [backgroundForm] = Form.useForm();
   const [loading, setLoading] = useState({
     content: false,
     layer: false,
-    filter: false
+    filter: false,
+    background: false
   });
 
   // Dynamic layer management
@@ -132,6 +134,23 @@ const StreamControls = ({ onAction, status, onLog }) => {
     }
   };
 
+  const handleUpdateBackground = async (values) => {
+    setLoading({ ...loading, background: true });
+    try {
+      const result = await onAction('background', values);
+      if (result.success) {
+        message.success('Background updated successfully');
+        backgroundForm.resetFields();
+      } else {
+        message.error(result.message || 'Failed to update background');
+      }
+    } catch (error) {
+      message.error('Failed to update background');
+    } finally {
+      setLoading({ ...loading, background: false });
+    }
+  };
+
   const handleSendFilter = async (values) => {
     setLoading({ ...loading, filter: true });
     try {
@@ -202,6 +221,62 @@ const StreamControls = ({ onAction, status, onLog }) => {
 
   return (
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      {/* Background Settings */}
+      <Card
+        title={
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <VideoCameraOutlined style={{ color: '#1890ff' }} />
+            <Title level={5} style={{ margin: 0, color: '#ffffff' }}>
+              Background Layer
+            </Title>
+          </div>
+        }
+        size="small"
+      >
+        <Form
+          form={backgroundForm}
+          layout="vertical"
+          onFinish={handleUpdateBackground}
+        >
+          <Form.Item
+            label={<Text style={{ color: '#ffffff' }}>Color</Text>}
+            name="color"
+          >
+            <Input
+              placeholder="e.g., black or #000000"
+              style={{ background: '#262626', border: '1px solid #404040', color: '#ffffff' }}
+            />
+          </Form.Item>
+          <Form.Item
+            label={<Text style={{ color: '#ffffff' }}>Text</Text>}
+            name="text"
+          >
+            <Input
+              placeholder="Optional text"
+              style={{ background: '#262626', border: '1px solid #404040', color: '#ffffff' }}
+            />
+          </Form.Item>
+          <Form.Item style={{ marginBottom: 0 }}>
+            <Button
+              type="primary"
+              htmlType="submit"
+              icon={<SendOutlined />}
+              loading={loading.background}
+              disabled={status.ffmpeg !== 'running'}
+              block
+            >
+              Update Background
+            </Button>
+          </Form.Item>
+        </Form>
+
+        <div style={{ marginTop: '8px' }}>
+          <Text type="secondary" style={{ fontSize: '12px' }}>
+            Sets the persistent background color and optional text.
+          </Text>
+        </div>
+      </Card>
+
       {/* Content Update */}
       <Card
         title={

--- a/web/src/services/StreamService.js
+++ b/web/src/services/StreamService.js
@@ -154,7 +154,14 @@ export class StreamService {
             }
           };
           break;
-          
+
+        case 'background':
+          payload = {
+            type: 'background',
+            data
+          };
+          break;
+
         default:
           throw new Error(`Unknown update type: ${type}`);
       }


### PR DESCRIPTION
## Summary
- add persistent background layer with configurable color and text
- allow background updates via API and web dashboard
- update FFmpeg pipeline to mix background with content and overlays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ab839d1bc8325a5416484bfb53c1f